### PR TITLE
Migration path is missing for MongoDB (mongoose)

### DIFF
--- a/docs/3.0.0-beta.x/migration-guide/migration-guide-beta.15-to-beta.16.md
+++ b/docs/3.0.0-beta.x/migration-guide/migration-guide-beta.15-to-beta.16.md
@@ -8,6 +8,8 @@ Start by upgrading all your strapi package version to `3.0.0-beta.16`.
 
 Your package.json would look like this:
 
+If you're using bookshelf (PostgreSQL, MySQL, and SQLite3)
+
 ```json
 {
   //...
@@ -24,6 +26,28 @@ Your package.json would look like this:
     "strapi-plugin-upload": "3.0.0-beta.16",
     "strapi-plugin-users-permissions": "3.0.0-beta.16",
     "strapi-utils": "3.0.0-beta.16"
+  }
+}
+```
+
+If you're using mongoose (MongoDB)
+
+```json
+{
+  //...
+  "dependencies": {
+    "strapi": "3.0.0-beta.16",
+    "strapi-admin": "^3.0.0-beta.16",
+    "strapi-hook-mongoose": "^3.0.0-beta.16",
+    "strapi-plugin-content-manager": "^3.0.0-beta.16",
+    "strapi-plugin-content-type-builder": "^3.0.0-beta.16",
+    "strapi-plugin-documentation": "3.0.0-beta.16",
+    "strapi-plugin-email": "3.0.0-beta.16",
+    "strapi-plugin-graphql": "3.0.0-beta.16",
+    "strapi-plugin-settings-manager": "^3.0.0-beta.16",
+    "strapi-plugin-upload": "^3.0.0-beta.16",
+    "strapi-plugin-users-permissions": "^3.0.0-beta.16",
+    "strapi-utils": "^3.0.0-beta.16"
   }
 }
 ```


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
Added migration info for developers using MongoDB/mongoose when [migrating from beta15 to beta16](https://strapi.io/documentation/3.0.0-beta.x/migration-guide/migration-guide-beta.15-to-beta.16.html#upgrading-your-dependencies). Potentially related to https://github.com/strapi/strapi/issues/4015
<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [x] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
