### PR TITLE
Add note: bootstrap.js function is required

### DIFF
--- a/docs/3.0.0-beta.x/migration-guide/migration-guide-beta.15-to-beta.16.md
+++ b/docs/3.0.0-beta.x/migration-guide/migration-guide-beta.15-to-beta.16.md
@@ -183,6 +183,14 @@ module.exports = () => {
 };
 ```
 
+**Empty Function**
+
+When updating `config/functions/bootstrap.js` to remove `cb()` a bootstrap function is required. If you're not using this feature drop in a blank sync function: 
+```js
+module.exports = () => {};
+```
+
+
 ### Custom hooks
 
 If you have custom [hooks](../advanced/hooks.md) in your project, the `initialize` function will not receive a callback anymore. You can either use an async function, return a promise or simply run a synchronous function.


### PR DESCRIPTION
When updating strapi to beta16 following [migration doc](https://strapi.io/documentation/3.0.0-beta.x/migration-guide/migration-guide-beta.15-to-beta.16.html) it's mentioned that [cb() must be removed](https://strapi.io/documentation/3.0.0-beta.x/migration-guide/migration-guide-beta.15-to-beta.16.html#bootstrap-function). Alternatives are provided, however it isn't mentioned that "any function" is required. This change provides a workaround until a user provided bootstrap function is no longer required ... maybe?

Without bootstrap.js exporting a valid function you get this error:
```
error TypeError: fn is not a function
    at execBootstrap (.../src/node_modules/strapi/lib/Strapi.js:381:15)
    at Strapi.runBootstrapFunctions (../src/node_modules/strapi/lib/Strapi.js:399:12)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
Added migration note for developers that are not using a `config/functions/bootstrap.js` bootstrap function. 

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [x] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
